### PR TITLE
Optional visual switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,18 @@ This extension was originally developed as part of the [jupyterlab-topbar](https
 
 ## Installation
 
-This extension requires the `jupyterlab-topbar-extension` extension for JupyterLab.
+This extension requires the `jupyterlab-topbar-extension` extension for JupyterLab to display the visual switch:
 
 ```bash
 jupyter labextension install jupyterlab-topbar-extension jupyterlab-theme-toggle
 ```
+
+To only install the keyboard shortcut (`Cmd/Ctrl+y` by default):
+
+```bash
+jupyter labextension install jupyterlab-theme-toggle
+```
+
 
 ## Development
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     topBar: ITopBar
   ) => {
     // TODO: make this configurable via the settings?
-    let themes = [
+    const themes = [
       "JupyterLab Light", // Light Theme goes first
       "JupyterLab Dark"
     ];
@@ -113,7 +113,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     })
 
     if (topBar) {
-      let widget = ReactWidget.create(
+      const widget = ReactWidget.create(
         <Switch
           themeManager={themeManager}
           onChange={onChange}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,8 @@ class Switch extends React.Component<ISwitchProps, ISwitchState> {
 const extension: JupyterFrontEndPlugin<void> = {
   id: "jupyterlab-theme-toggle:plugin",
   autoStart: true,
-  requires: [IThemeManager, ITopBar],
+  requires: [IThemeManager],
+  optional: [ITopBar],
   activate: (
     app: JupyterFrontEnd,
     themeManager: IThemeManager,
@@ -105,22 +106,23 @@ const extension: JupyterFrontEndPlugin<void> = {
       });
     };
 
-    let widget = ReactWidget.create(
-      <Switch
-        themeManager={themeManager}
-        onChange={onChange}
-        innerLabel="light"
-        innerLabelChecked="dark"
-      />
-    );
-
     const { commands } = app;
     commands.addCommand('jupyterlab-theme-toggle:toggle', {
       label: "Toggle Theme",
       execute: onChange
     })
 
-    topBar.addItem("theme-toggle", widget);
+    if (topBar) {
+      let widget = ReactWidget.create(
+        <Switch
+          themeManager={themeManager}
+          onChange={onChange}
+          innerLabel="light"
+          innerLabelChecked="dark"
+        />
+      );
+      topBar.addItem("theme-toggle", widget);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #4.

The visual switch is now optional while keeping the keyboard shortcut available.

To install without the topbar extension:

```
jupyter labextension install jupyterlab-theme-toggle
```

cc @tbrodbeck